### PR TITLE
[pub] feat: add ORAL badge for LoongRL

### DIFF
--- a/src/data/publications.ts
+++ b/src/data/publications.ts
@@ -7,6 +7,7 @@ export type Publication = {
 	title: string;
 	link: string;
 	venue: string;
+	badges?: string[];
 	authors: Author[];
 };
 
@@ -29,6 +30,7 @@ export const publications: Publication[] = [
 		title: "LoongRL: Reinforcement Learning for Advanced Reasoning over Long Contexts",
 		link: "https://arxiv.org/abs/2510.19363",
 		venue: "ICLR 2026",
+		badges: ["ORAL"],
 		authors: [
 			{ name: "Siyuan Wang", coFirst: true },
 			{ name: "Gaokai Zhang", coFirst: true },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -83,9 +83,14 @@ const publicationsPreview = publications.slice(0, MAX_PUBLICATIONS_PREVIEW);
 								{pub.title}
 							</a>
 						</h3>
-						<span class="inline-flex max-w-fit items-center whitespace-nowrap rounded-full border border-zinc-400 px-3 py-1 text-xs uppercase tracking-wide dark:border-zinc-500">
-							{pub.venue}
-						</span>
+						<div class="flex flex-wrap items-center gap-2">
+							<span class="inline-flex max-w-fit items-center whitespace-nowrap rounded-full border border-zinc-400 px-3 py-1 text-xs uppercase tracking-wide dark:border-zinc-500">
+								{pub.venue}
+							</span>
+							{pub.badges?.map((badge) => (
+								<span class="pub-badge pub-badge--oral">{badge}</span>
+							))}
+						</div>
 					</div>
 					<p class="text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
 						{pub.authors.map((author, idx) => (

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -88,7 +88,7 @@ const publicationsPreview = publications.slice(0, MAX_PUBLICATIONS_PREVIEW);
 								{pub.venue}
 							</span>
 							{pub.badges?.map((badge) => (
-								<span class="pub-badge pub-badge--oral">{badge}</span>
+								<span class={`pub-badge pub-badge--${badge.toLowerCase()}`}>{badge}</span>
 							))}
 						</div>
 					</div>

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -24,9 +24,14 @@ const highlightName = "Siyuan Wang";
 							{pub.title}
 						</a>
 					</h2>
-					<span class="inline-flex max-w-fit items-center rounded-full border border-zinc-400 px-3 py-1 text-xs uppercase tracking-wide whitespace-nowrap dark:border-zinc-500">
-						{pub.venue}
-					</span>
+					<div class="flex flex-wrap items-center gap-2">
+						<span class="inline-flex max-w-fit items-center rounded-full border border-zinc-400 px-3 py-1 text-xs uppercase tracking-wide whitespace-nowrap dark:border-zinc-500">
+							{pub.venue}
+						</span>
+						{pub.badges?.map((badge) => (
+							<span class="pub-badge pub-badge--oral">{badge}</span>
+						))}
+					</div>
 				</div>
 				<p class="text-sm leading-relaxed">
 					{pub.authors.map((author, idx) => (

--- a/src/pages/publications.astro
+++ b/src/pages/publications.astro
@@ -29,7 +29,7 @@ const highlightName = "Siyuan Wang";
 							{pub.venue}
 						</span>
 						{pub.badges?.map((badge) => (
-							<span class="pub-badge pub-badge--oral">{badge}</span>
+							<span class={`pub-badge pub-badge--${badge.toLowerCase()}`}>{badge}</span>
 						))}
 					</div>
 				</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,6 +117,25 @@
 		font-size: 0.65em;
 		line-height: 1;
 	}
+
+	.pub-badge {
+		display: inline-flex;
+		align-items: center;
+		border-radius: 9999px;
+		padding: 0.25rem 0.5rem;
+		font-size: 0.65rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		white-space: nowrap;
+		border: 1px solid oklch(from var(--color-accent) l c h / 0.35);
+		background: oklch(from var(--color-accent) l c h / 0.12);
+		color: var(--color-accent);
+	}
+
+	.pub-badge--oral {
+		box-shadow: 0 0 0 1px oklch(from var(--color-accent) l c h / 0.1) inset;
+	}
 }
 
 @utility prose {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publications can now show one or more badges to highlight special designations (e.g., "ORAL").
* **Style**
  * Added visual styles and a distinct variant for publication badges to improve visibility and emphasis.
* **UI**
  * Publication listings updated to layout venue and badges together for clearer presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->