### PR TITLE
[projects] feat: reorder sections and add KeepGPU details

### DIFF
--- a/docs/plans/projects-reorder-keepgpu.md
+++ b/docs/plans/projects-reorder-keepgpu.md
@@ -1,0 +1,21 @@
+# Projects Page Reorder + KeepGPU Entry
+
+## Background
+The current Projects page lists "Open Source Contributions" before "Competitions & Demos". The requested layout is the opposite order, and a new KeepGPU item should be added based on repository information.
+
+## Goal
+1. Show "Competitions & Demos" above "Open Source Contributions".
+2. Add a KeepGPU entry in Open Source with accurate, concise content.
+3. Keep page structure and styling unchanged.
+
+## Solution
+- Update `src/data/projects.ts` ordering in `projectCategories`.
+- Insert a new `ProjectItem` for KeepGPU under Open Source.
+- Use GitHub metadata (`description`, repo URL, language/license context) for truthful copy.
+
+## Todo
+- [x] Inspect current projects rendering and data order.
+- [x] Fetch KeepGPU metadata with GitHub CLI.
+- [x] Reorder categories in `src/data/projects.ts`.
+- [x] Add KeepGPU project entry.
+- [x] Run `pnpm check` and confirm no regressions.

--- a/docs/plans/projects-reorder-keepgpu.md
+++ b/docs/plans/projects-reorder-keepgpu.md
@@ -5,12 +5,12 @@ The current Projects page lists "Open Source Contributions" before "Competitions
 
 ## Goal
 1. Show "Competitions & Demos" above "Open Source Contributions".
-2. Add a KeepGPU entry in Open Source with accurate, concise content.
+2. Add a KeepGPU entry in Competitions & Demos with accurate, concise content.
 3. Keep page structure and styling unchanged.
 
 ## Solution
 - Update `src/data/projects.ts` ordering in `projectCategories`.
-- Insert a new `ProjectItem` for KeepGPU under Open Source.
+- Insert a new `ProjectItem` for KeepGPU under Competitions & Demos.
 - Use GitHub metadata (`description`, repo URL, language/license context) for truthful copy.
 
 ## Todo

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -19,6 +19,15 @@ export const projectCategories: ProjectCategory[] = [
 		title: "Competitions & Demos",
 		items: [
 			{
+				title: "KeepGPU",
+				role: "Maintainer",
+				period: "2025-2026",
+				link: "https://github.com/Wangmerlyn/KeepGPU",
+				description:
+					"Built and maintain a Python CLI tool that keeps shared GPUs active with lightweight keep-alive workloads, plus a matching Python API.",
+				tags: ["python", "GPU tooling", "CLI"],
+			},
+			{
 				title: "Kaggle LMSYS – Chatbot Arena Preference Prediction",
 				role: "Team Lead & Algorithm Designer",
 				period: "Aug 2024",
@@ -49,15 +58,6 @@ export const projectCategories: ProjectCategory[] = [
 	{
 		title: "Open Source Contributions",
 		items: [
-			{
-				title: "KeepGPU",
-				role: "Maintainer",
-				period: "2025-2026",
-				link: "https://github.com/Wangmerlyn/KeepGPU",
-				description:
-					"Built and maintain a Python CLI tool that keeps shared GPUs active with lightweight keep-alive workloads, plus a matching Python API.",
-				tags: ["python", "GPU tooling", "CLI"],
-			},
 			{
 				title: "vLLM",
 				role: "Contributor",

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -31,6 +31,7 @@ export const projectCategories: ProjectCategory[] = [
 				title: "Kaggle LMSYS – Chatbot Arena Preference Prediction",
 				role: "Team Lead & Algorithm Designer",
 				period: "Aug 2024",
+				link: "https://www.kaggle.com/competitions/lmsys-chatbot-arena",
 				description:
 					"Built LoRA‑fine‑tuned models with pseudo‑labeling and ensembles; earned Silver Medal (39/1,849 teams).",
 				tags: ["Kaggle", "preference modeling", "LoRA"],

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -16,8 +16,48 @@ export type ProjectCategory = {
 
 export const projectCategories: ProjectCategory[] = [
 	{
+		title: "Competitions & Demos",
+		items: [
+			{
+				title: "Kaggle LMSYS – Chatbot Arena Preference Prediction",
+				role: "Team Lead & Algorithm Designer",
+				period: "Aug 2024",
+				description:
+					"Built LoRA‑fine‑tuned models with pseudo‑labeling and ensembles; earned Silver Medal (39/1,849 teams).",
+				tags: ["Kaggle", "preference modeling", "LoRA"],
+			},
+			{
+				title: "LLM‑MCTS Reasoning from Scratch",
+				role: "Lead & Algorithm Designer",
+				period: "Jan 2025",
+				link: "https://github.com/Wangmerlyn/MCTS-GSM8k-Demo",
+				description:
+					"Lightweight Monte‑Carlo Tree Search pipeline for LLM agents; supports OpenAI/DeepSeek APIs with optimized rollout policy.",
+				tags: ["LLM", "MCTS", "agents"],
+			},
+			{
+				title: "Jung's Letter (NetEase MINIGAME 2022)",
+				role: "Architect & Lead Programmer",
+				period: "Oct 2022",
+				link: "https://www.bilibili.com/video/BV1eD4y1b7oa",
+				description:
+					"2.5D narrative adventure; produced teaser and achieved charity certification from Beijing New Sunshine Charity Foundation.",
+				tags: ["game dev", "narrative", "unity"],
+			},
+		],
+	},
+	{
 		title: "Open Source Contributions",
 		items: [
+			{
+				title: "KeepGPU",
+				role: "Maintainer",
+				period: "2025-2026",
+				link: "https://github.com/Wangmerlyn/KeepGPU",
+				description:
+					"Built and maintain a Python CLI tool that keeps shared GPUs active with lightweight keep-alive workloads, plus a matching Python API.",
+				tags: ["python", "GPU tooling", "CLI"],
+			},
 			{
 				title: "vLLM",
 				role: "Contributor",
@@ -55,37 +95,6 @@ export const projectCategories: ProjectCategory[] = [
 						url: "https://github.com/nightdessert/Retrieval_Head",
 					},
 				],
-			},
-		],
-	},
-	{
-		title: "Competitions & Demos",
-		items: [
-			{
-				title: "Kaggle LMSYS – Chatbot Arena Preference Prediction",
-				role: "Team Lead & Algorithm Designer",
-				period: "Aug 2024",
-				description:
-					"Built LoRA‑fine‑tuned models with pseudo‑labeling and ensembles; earned Silver Medal (39/1,849 teams).",
-				tags: ["Kaggle", "preference modeling", "LoRA"],
-			},
-			{
-				title: "LLM‑MCTS Reasoning from Scratch",
-				role: "Lead & Algorithm Designer",
-				period: "Jan 2025",
-				link: "https://github.com/Wangmerlyn/MCTS-GSM8k-Demo",
-				description:
-					"Lightweight Monte‑Carlo Tree Search pipeline for LLM agents; supports OpenAI/DeepSeek APIs with optimized rollout policy.",
-				tags: ["LLM", "MCTS", "agents"],
-			},
-			{
-				title: "Jung's Letter (NetEase MINIGAME 2022)",
-				role: "Architect & Lead Programmer",
-				period: "Oct 2022",
-				link: "https://www.bilibili.com/video/BV1eD4y1b7oa",
-				description:
-					"2.5D narrative adventure; produced teaser and achieved charity certification from Beijing New Sunshine Charity Foundation.",
-				tags: ["game dev", "narrative", "unity"],
 			},
 		],
 	},


### PR DESCRIPTION
## Summary
- move `Competitions & Demos` above `Open Source Contributions`
- add KeepGPU project entry and place it in Competitions & Demos
- add Kaggle LMSYS competition link

## Validation
- pnpm check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KeepGPU to the Projects page.
  * Created a "Competitions & Demos" category, now prominently featured at the top of the Projects page, grouping competition and demo projects together for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->